### PR TITLE
Update the message URL for the iOS 11 "change"

### DIFF
--- a/Support/bin/add
+++ b/Support/bin/add
@@ -14,7 +14,7 @@ begin
   tmpfile.puts(ENV['MM_SUBJECT'])
 
   # The rest is the note
-  tmpfile.puts("Email: message://%3c" + CGI::escape(ENV['MM_MESSAGE_ID']) + "%3e")
+  tmpfile.puts("Email<message:%3c" + ENV['MM_MESSAGE_ID'] + "%3e>")
 
   canonical = $stdin.read
   if !canonical.empty?


### PR DESCRIPTION
Ok, I believe I finally got a format that works.

1. I had to use this format: `Email<message:%3cMESSAGE_ID_STRUCTURE%3e>`
2. I had to remove the string escaping.

This doesn't seem to be causing me any adverse effects, but I don't have a lot of testing under this yet. I just clipped 10+ emails over the last 6 months and tested them on both macOS & iOS (which worked fine here). 😄